### PR TITLE
Changed moduleName lookup

### DIFF
--- a/lib/rules/prefer-node-protocol.js
+++ b/lib/rules/prefer-node-protocol.js
@@ -30,7 +30,7 @@ module.exports = {
 			}
 
 			const moduleName = source.value;
-			if (moduleName.startsWith("node:") || !nodeBuiltins.has(moduleName)) {
+			if (!nodeBuiltins.has(moduleName)) {
 				return;
 			}
 

--- a/lib/rules/prefer-node-protocol.js
+++ b/lib/rules/prefer-node-protocol.js
@@ -1,6 +1,8 @@
 const { builtinModules } = require("module");
 
-const nodeBuiltins = new Set(builtinModules);
+const notBunModule = (m) => m !== "bun" && !m.startsWith("bun:");
+
+const nodeBuiltins = new Set(builtinModules.filter(notBunModule));
 
 const MESSAGE_ID = "prefer-node-protocol";
 

--- a/lib/rules/prefer-node-protocol.js
+++ b/lib/rules/prefer-node-protocol.js
@@ -1,5 +1,7 @@
 const { builtinModules } = require("module");
 
+const nodeBuiltins = new Set(builtinModules);
+
 const MESSAGE_ID = "prefer-node-protocol";
 
 /** @type {import("eslint").Rule.RuleModule} */
@@ -26,10 +28,7 @@ module.exports = {
 			}
 
 			const moduleName = source.value;
-			if (
-				moduleName.startsWith("node:") ||
-				!builtinModules.includes(moduleName)
-			) {
+			if (moduleName.startsWith("node:") || !nodeBuiltins.has(moduleName)) {
 				return;
 			}
 


### PR DESCRIPTION
Quick benchmarking of on a couple of differnt runtimes (node 18 and 20, and bun) indicates that Set lookup misses are quite a bit faster than Array search misses (Assuming most module names in large codebases are not node builtins)

```sh
$ nvm use 18
Now using node v18.16.0 (npm v9.5.1)
$ node lookups.mjs 
Array#includes: 783.162ms
Set#has: 99.131ms
Object[key]: 289.807ms
key in Object: 405.481ms

$ nvm use 20
Now using node v20.5.1 (npm v9.8.0)
$ node lookups.mjs 
Array#includes: 815.009ms
Set#has: 7.218ms
Object[key]: 325.319ms
key in Object: 394.132ms

$ bun --version
1.0.0
$ bun run lookups.mjs 
[3.15s] Array#includes
[12.25ms] Set#has
[79.16ms] Object[key]
[218.26ms] key in Object
```

Also Fixes: #7 — assuming the Bun team eventually fix https://github.com/oven-sh/bun/issues/3154