### PR TITLE
fix: support Node.js v23.5.0+

### DIFF
--- a/lib/rules/prefer-node-protocol.js
+++ b/lib/rules/prefer-node-protocol.js
@@ -30,7 +30,7 @@ module.exports = {
 			}
 
 			const moduleName = source.value;
-			if (!nodeBuiltins.has(moduleName)) {
+			if (!nodeBuiltins.has(moduleName) || moduleName.startsWith("node:")) {
 				return;
 			}
 

--- a/tests/lib/rules/prefer-node-protocol.test.js
+++ b/tests/lib/rules/prefer-node-protocol.test.js
@@ -27,6 +27,7 @@ cjsTester.run("prefer-node-protocol (require)", rule, {
 		{ code: "const fs = require();" },
 		{ code: 'const fs = require(...["fs"]);' },
 		{ code: 'const fs = require("eslint");' },
+		{ code: 'const test = require("node:test");' },
 	],
 	invalid: [
 		{
@@ -67,6 +68,7 @@ esmTester.run("prefer-node-protocol (import)", rule, {
 		{ code: "async function foo() {\nconst fs = await import(`fs`);\n}" },
 		{ code: 'import "punycode/"' },
 		{ code: 'export const DEFAULT_REGION = "alt-ww"' },
+		{ code: 'import test from "node:test";' },
 	],
 	invalid: [
 		{


### PR DESCRIPTION
Added a naive string match to avoid failures when prefix-only modules are referenced in Node.js v23.5.0+.

Fixes #10
